### PR TITLE
Changes to support AInstancedMeshManager

### DIFF
--- a/Source/SkeletonKey/Private/TransformDispatch.cpp
+++ b/Source/SkeletonKey/Private/TransformDispatch.cpp
@@ -19,7 +19,7 @@ void UTransformDispatch::RegisterObjectToShadowTransform(FSkeletonKey Target, TO
 	ObjectToTransformMapping->Add(Target, kine);
 }
 
-void UTransformDispatch::RegisterObjectToShadowTransform(FSkeletonKey Target, UAUKineManager* Manager) const
+void UTransformDispatch::RegisterObjectToShadowTransform(FSkeletonKey Target, USwarmKineManager* Manager) const
 {
 	//explicitly cast to parent type.
 	TSharedPtr<Kine> kine = MakeShareable<SwarmKine>(new SwarmKine(Manager, Target));

--- a/Source/SkeletonKey/Public/TransformDispatch.h
+++ b/Source/SkeletonKey/Public/TransformDispatch.h
@@ -28,7 +28,7 @@ class SKELETONKEY_API UTransformDispatch : public UTickableWorldSubsystem
 
 public:
 	void RegisterObjectToShadowTransform(FSkeletonKey Target, TObjectPtr<AActor> Original) const;
-	void RegisterObjectToShadowTransform(FSkeletonKey Target, UAUKineManager* Manager) const;
+	void RegisterObjectToShadowTransform(FSkeletonKey Target, USwarmKineManager* Manager) const;
 
 	//this provides support for new kinds of kines transparent to skeletonkey. kine bravely!
 	//for many many kines, manager is going to be a self pointer, but not all!


### PR DESCRIPTION
This allows for us to spawn as many Jolt enabled instances of the same mesh as we want under the same actor